### PR TITLE
Asmdef support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,12 @@ public class EventBusTest : MonoBehaviour
         }
 ```
 
+4. Using Assembly Definitions
+
+once in your custom assembly mark the assembly, such that it can be cleaned up properly in the Editor even without Domain reload
+
+```
+[assembly: EventBus.EventBusAssembly()]
+```
+
 


### PR DESCRIPTION
fix: clearing was using the wrong type and clear method could never be found
fix: clearing of custom assemblies was not possible
feat: added assembly attribute to mark custom assemblies.